### PR TITLE
fix: sidebar navigation arrow pointing right on collapse

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -144,9 +144,14 @@ const LinkList = styled(List)`
   flex: 1;
 `;
 
-const CollapseMenuItem = styled(MenuItemButton)`
+const CollapseMenuItem = styled(MenuItemButton)<{ isCollapsed: boolean }>`
   display: none;
-
+  & img {
+    transform: rotate(
+      ${({ isCollapsed }) => (isCollapsed ? "180deg" : "0deg")}
+    );
+    transition: all 300ms;
+  }
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
   }


### PR DESCRIPTION
The arrow of the collapse button now points to the right when the sidebar navigation is collapsed.