### PR TITLE
fix: separator line reduced to 1px thick to match the designs

### DIFF
--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -39,7 +39,7 @@ const TopContainer = styled.div`
 
 const BottomContainer = styled.div`
   padding: ${space(4, 6)};
-  border-top: 3px solid ${color("gray", 200)};
+  border-top: 1px solid ${color("gray", 200)};
   display: flex;
   justify-content: flex-end;
 `;


### PR DESCRIPTION
The thickness of the separator line is changed to 1px to match the design in Figma.