### PR TITLE
fix: color of pager info is changed to Gray/700 to match the design

### DIFF
--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -54,7 +54,7 @@ const PaginationButton = styled.button`
 `;
 
 const PageInfo = styled.div`
-  color: ${color("gray", 300)};
+  color: ${color("gray", 700)};
   ${textFont("sm", "regular")}
 `;
 


### PR DESCRIPTION
The color of the page info matches the designs