### PR TITLE
fix: support button to open email client

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -31,6 +31,17 @@ describe("Sidebar Navigation", () => {
         .should("have.attr", "href", "/dashboard/settings");
     });
 
+    it("Support link opens an email client on click", () => {
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("Open");
+      });
+      cy.get("nav").contains("Support").click();
+      cy.get("@Open").should(
+        "have.been.calledOnceWith",
+        "mailto:support@prolog-app.com?subject=Support Request:"
+      );
+    });
+
     it("is collapsible", () => {
       // collapse navigation
       cy.get("nav").contains("Collapse").click();

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -161,6 +161,11 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const openEmailClient = () => {
+    window.open("mailto:support@prolog-app.com?subject=Support Request:");
+  };
+
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
@@ -198,7 +203,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={openEmailClient}
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
The recipient should be “support@prolog-app.com”
The subject line should be pre-filled with “Support Request: “
A Cypress test to verify window.open has been called with the correct mailto request.