### PR TITLE
fix: show the correct project status

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,10 +5,12 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  info = "stable",
   warning = "warning",
-  critical = "critical",
+  error = "critical",
 }
+
+export type ProjectStatusText = keyof typeof ProjectStatus;
 
 export type Project = {
   id: string;
@@ -16,5 +18,5 @@ export type Project = {
   language: ProjectLanguage;
   numIssues: number;
   numEvents24h: number;
-  status: ProjectStatus;
+  status: ProjectStatusText;
 };

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,6 +1,8 @@
 import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
 
+import { ProjectStatus, ProjectStatusText } from "../../api/projects.types";
+
 describe("Project List", () => {
   beforeEach(() => {
     // setup request mock
@@ -32,7 +34,11 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el).contains(
+            capitalize(
+              ProjectStatus[mockProjects[index].status as ProjectStatusText]
+            )
+          );
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { ProjectCard } from "./project-card";
-import { ProjectLanguage, ProjectStatus } from "@api/projects.types";
+import { ProjectLanguage } from "@api/projects.types";
 
 export default {
   title: "Project/ProjectCard",
@@ -26,7 +26,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: "error",
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -18,9 +18,9 @@ const languageNames = {
 };
 
 const statusColors = {
-  [ProjectStatus.stable]: BadgeColor.success,
-  [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  info: BadgeColor.success,
+  warning: BadgeColor.warning,
+  error: BadgeColor.error,
 };
 
 const Container = styled.div`
@@ -123,7 +123,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <IssuesNumber>{numEvents24h}</IssuesNumber>
           </Issues>
           <Status>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>
+              {capitalize(ProjectStatus[status])}
+            </Badge>
           </Status>
         </InfoContainer>
       </TopContainer>


### PR DESCRIPTION
Show the text “Critical” for the error status and “Stable” for the info status with the correct colour labels.